### PR TITLE
HTML5 meta charset.

### DIFF
--- a/test/unit.php
+++ b/test/unit.php
@@ -19,7 +19,7 @@ $time_start = microtime(true);
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta charset="utf-8">
         <title>JpnForPhp library - unit tests</title>
         <style>
             body {


### PR DESCRIPTION
There is no need for the ugly 

``` html
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
```

in the test page.
