### PR TITLE
fixed bug for loading YAML

### DIFF
--- a/src/JpnForPhp/Transliterator/TransliterationSystem.php
+++ b/src/JpnForPhp/Transliterator/TransliterationSystem.php
@@ -32,7 +32,7 @@ abstract class TransliterationSystem
      */
     public function __construct($file)
     {
-        $this->configuration = Yaml::parse($file);
+        $this->configuration = Yaml::parse(file_get_contents($file));
     }
 
     /**


### PR DESCRIPTION
The Yaml lib expects the file contents not name: http://symfony.com/doc/current/components/yaml/introduction.html