### PR TITLE
flush latin characters buffer after doing transliteration

### DIFF
--- a/src/JpnForPhp/Transliterator/Romaji.php
+++ b/src/JpnForPhp/Transliterator/Romaji.php
@@ -189,6 +189,7 @@ class Romaji extends TransliterationSystem
     {
         if ($this->latinCharacters) {
             $str = vsprintf($str, $this->latinCharacters);
+            $this->latinCharacters = array();
         }
 
         return $str;

--- a/tests/JpnForPhp/Transliterator/TransliteratorTest.php
+++ b/tests/JpnForPhp/Transliterator/TransliteratorTest.php
@@ -66,6 +66,15 @@ class TransliteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('yahoo YAHOO', $result);
     }
 
+    public function testTransliterateToRomajiWithHepburnWhenLatinOnlyForMultipleTimes()
+    {
+        $result = self::$hepburn->transliterate('hello:world');
+        $this->assertEquals('hello:world', $result);
+        
+        $result = self::$hepburn->transliterate('it:works');
+        $this->assertEquals('it:works', $result);
+    }
+
     public function testTransliterateToRomajiWithHepburnWhenLongVowels()
     {
         $result = self::$hepburn->transliterate('がっこう');


### PR DESCRIPTION
This fixes an issue when the same transliterator is used multiple times for a given pattern of words in latin. 
e.g. if transliterator is invoked with text 'hello:world' and then 'it:works', currently it always returns 'hello:world' for both cases.  

The fix is to flush the latinCharacters buffer.